### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Plugin use CSS Style injection to set `display: none` on useless elements.
 
 ##  License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.